### PR TITLE
add gnu-plot to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,10 @@ ENV OMP_NUM_THREADS=1
 RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus
 RUN cd /opt/octopus-examples/he && mpirun -np 2 octopus
 
+# Add optional packages not needed by octopus (for visualization)
+RUN apt-get -y update && apt-get -y install gnuplot \
+    && rm -rf /var/lib/apt/lists/*
+
 # offer directory for mounting container
 WORKDIR /io
 

--- a/Dockerfile-develop
+++ b/Dockerfile-develop
@@ -83,6 +83,10 @@ ENV OMP_NUM_THREADS=1
 RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus
 RUN cd /opt/octopus-examples/he && mpirun -np 2 octopus
 
+# Add optional packages not needed by octopus (for visualization)
+RUN apt-get -y update && apt-get -y install gnuplot \
+    && rm -rf /var/lib/apt/lists/*
+    
 # offer directory for mounting container
 WORKDIR /io
 


### PR DESCRIPTION
Gnu-plot is often used with octopus ( and is also currently the recommended way to plot in octopus-tutorials) so it would be a good idea to add it to the docker image.