### PR TITLE
update to Octopus version 13.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-# install Octopus 12.2 on Debian
+# install Octopus 13.0 on Debian
 
 # Convenience tools (up to emacs)
 # Libraries that octopus needs 
@@ -41,9 +41,9 @@ RUN apt-get -y update && apt-get -y install wget time nano vim emacs \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
-RUN wget -O oct.tar.gz http://octopus-code.org/down.php?file=12.2/octopus-12.2.tar.gz && tar xfvz oct.tar.gz && rm oct.tar.gz
+RUN wget -O oct.tar.gz https://octopus-code.org/download/13.0/octopus-13.0.tar.gz && tar xfvz oct.tar.gz && rm oct.tar.gz
 
-WORKDIR /opt/octopus-12.2
+WORKDIR /opt/octopus-13.0
 RUN autoreconf -i
 RUN ./configure --enable-mpi --enable-openmp
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,10 @@ RUN apt-get -y update && apt-get -y install wget time nano vim emacs \
     procps \
     && rm -rf /var/lib/apt/lists/*
 
+# Add optional packages not needed by octopus (for visualization)
+RUN apt-get -y update && apt-get -y install gnuplot \
+  && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt
 RUN wget -O oct.tar.gz https://octopus-code.org/download/13.0/octopus-13.0.tar.gz && tar xfvz oct.tar.gz && rm oct.tar.gz
 
@@ -78,10 +82,6 @@ ENV OMP_NUM_THREADS=1
 # run one MPI-enabled version
 RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus
 RUN cd /opt/octopus-examples/he && mpirun -np 2 octopus
-
-# Add optional packages not needed by octopus (for visualization)
-RUN apt-get -y update && apt-get -y install gnuplot \
-    && rm -rf /var/lib/apt/lists/*
 
 # offer directory for mounting container
 WORKDIR /io

--- a/Dockerfile-develop
+++ b/Dockerfile-develop
@@ -40,6 +40,10 @@ RUN apt-get -y update && apt-get -y install wget time nano vim emacs \
     procps \
     && rm -rf /var/lib/apt/lists/*
 
+# Add optional packages not needed by octopus (for visualization)
+RUN apt-get -y update && apt-get -y install gnuplot \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /opt
 RUN git clone https://gitlab.com/octopus-code/octopus.git
 WORKDIR /opt/octopus
@@ -82,10 +86,6 @@ ENV OMP_NUM_THREADS=1
 # run one MPI-enabled version
 RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus
 RUN cd /opt/octopus-examples/he && mpirun -np 2 octopus
-
-# Add optional packages not needed by octopus (for visualization)
-RUN apt-get -y update && apt-get -y install gnuplot \
-    && rm -rf /var/lib/apt/lists/*
     
 # offer directory for mounting container
 WORKDIR /io

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ stable:
 develop:
 	docker build -f Dockerfile-develop -t octopus-develop .
 
-.PHONY: stable develop dockerhub-update-12.2
+.PHONY: stable develop dockerhub-update-13.0
 
-dockerhub-update-12.2:
-	docker build -f Dockerfile -t fangohr/octopus:12.2 .
+dockerhub-update-13.0:
+	docker build -f Dockerfile -t fangohr/octopus:13.0 .
 	@echo "If the container has built successfully, do this to push to dockerhub:"
 	@echo "Run 'docker login'"
-	@echo "Run 'docker push fangohr/octopus:12.2'"
-	@echo "Run 'docker tag fangohr/octopus:12.2 fangohr/octopus:latest'"
+	@echo "Run 'docker push fangohr/octopus:13.0'"
+	@echo "Run 'docker tag fangohr/octopus:13.0 fangohr/octopus:latest'"
 	@echo "Run 'docker push fangohr/octopus:latest'"

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Use cases: run octopus (for small calculations) conveniently in container, in pa
 Status 
 ------
 
-|stable| Debian Bullseye (11), Last octopus release (12.2)
+|stable| Debian Bullseye (11), Last octopus release (13.0)
 
 |develop| Debian Bullseye (11), Octopus develop branch
 
@@ -41,11 +41,11 @@ There are two steps required:
 Step 1: How obtain a Docker container image with Octopus
 --------------------------------------------------------
 
-We provide a `Dockerfile <Dockerfile>`__ to compile Octopus 12.2
+We provide a `Dockerfile <Dockerfile>`__ to compile Octopus 13.0
 and `Dockerfile-develop <Dockerfile-develop>`__ to compile the ``develop`` branch of the Octopus
 repository in a container.
 
-The following examples are for the 12.2 release version. (To build a container
+The following examples are for the 13.0 release version. (To build a container
 for the latest Octopus version from the ``develop`` branch, replace
 ``Dockerfile`` with ``Dockerfile-develop``.)
 
@@ -68,10 +68,10 @@ Option B: Download Docker image from Dockerhub
 Instead of building it yourself, you can also pull an image from Dockerhub
 (`available versions <https://hub.docker.com/r/fangohr/octopus/tags>`__) using::
 
-  docker pull fangohr/octopus:12.2
+  docker pull fangohr/octopus:13.0
 
 and then move on to using this image in the next section, where you replace
-``octimage`` with ``fangohr/octopus:12.2``.
+``octimage`` with ``fangohr/octopus:13.0``.
 
 [You should only use this "Option B" if your processor is x86 type. This is true
 for most CPUs - with the exception of the 'new' Apple M1 computers (which have


### PR DESCRIPTION
- update from octopus 12.2 to 13.0
- move installation of post-processing tools to the beginning of the Docker file: otherwise the output from the apt-get command hides the calls of octopus where it is useful to see the output.