### PR TITLE
Fix elpa linking

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
 # test that the libraries are mentioned in theOptional libraries section of octopus output
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "cgal"
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "scalapack"
-RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "elpa"
+RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "ELPA"
 
 # offer directory for mounting container
 WORKDIR /io

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,10 @@ RUN wget -O oct.tar.gz https://octopus-code.org/download/13.0/octopus-13.0.tar.g
 
 WORKDIR /opt/octopus-13.0
 RUN autoreconf -i
-RUN ./configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi"
+# We need to set FCFLAGS_ELPA as the octopus m4 has a bug
+# see https://gitlab.com/octopus-code/octopus/-/issues/900
+RUN export FCFLAGS_ELPA="-I/usr/include -I/usr/include/elpa/modules" && \
+    ./configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi"
 
 # Which optional dependencies are missing?
 RUN cat config.log | grep WARN > octopus-configlog-warnings
@@ -90,7 +93,7 @@ RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
 # test that the libraries are mentioned in theOptional libraries section of octopus output
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "cgal"
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "scalapack"
-
+RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "elpa"
 
 # offer directory for mounting container
 WORKDIR /io

--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,16 @@ ENV OMP_NUM_THREADS=1
 RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus
 RUN cd /opt/octopus-examples/he && mpirun -np 2 octopus
 
+# test the libraries used by octopus
+RUN cd /opt/octopus-examples/recipe && octopus > /tmp/octopus-recipe.out
+# test that the libraries are mentioned in the configuration options section of octopus output
+RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "openmp"
+RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
+# test that the libraries are mentioned in theOptional libraries section of octopus output
+RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "cgal"
+RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "scalapack"
+
+
 # offer directory for mounting container
 WORKDIR /io
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN cat config.log | grep WARN > octopus-configlog-warnings
 RUN cat octopus-configlog-warnings
 
 # all in one line to make image smaller
-RUN make && make install && make clean && make distclean
+RUN make -j && make install && make clean && make distclean
 
 RUN octopus --version > octopus-version
 RUN octopus --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm
 # install Octopus 13.0 on Debian
 
 # Convenience tools (up to emacs)
-# Libraries that octopus needs 
+# Libraries that octopus needs
 # and optional dependencies (in alphabetical order)
 RUN apt-get -y update && apt-get -y install wget time nano vim emacs \
     autoconf \
@@ -48,7 +48,7 @@ RUN wget -O oct.tar.gz https://octopus-code.org/download/13.0/octopus-13.0.tar.g
 
 WORKDIR /opt/octopus-13.0
 RUN autoreconf -i
-RUN ./configure --enable-mpi --enable-openmp
+RUN ./configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi"
 
 # Which optional dependencies are missing?
 RUN cat config.log | grep WARN > octopus-configlog-warnings

--- a/Dockerfile-develop
+++ b/Dockerfile-develop
@@ -52,7 +52,12 @@ RUN git show > octopus-source-version
 RUN echo "octopus-source-clone-date: $date " >> octopus-source-version
 
 RUN autoreconf -i
-RUN ./configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi"
+
+# We need to set FCFLAGS_ELPA as the octopus m4 has a bug
+# see https://gitlab.com/octopus-code/octopus/-/issues/900
+RUN export FCFLAGS_ELPA="-I/usr/include -I/usr/include/elpa/modules" && \
+    ./configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi"
+
 # Which optional dependencies are missing?
 RUN cat config.log | grep WARN > octopus-configlog-warnings
 RUN cat octopus-configlog-warnings
@@ -105,6 +110,7 @@ RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
 # test that the libraries are mentioned in theOptional libraries section of octopus output
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "cgal"
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "scalapack"
+RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "elpa"
 
 # offer directory for mounting container
 WORKDIR /io

--- a/Dockerfile-develop
+++ b/Dockerfile-develop
@@ -52,8 +52,7 @@ RUN git show > octopus-source-version
 RUN echo "octopus-source-clone-date: $date " >> octopus-source-version
 
 RUN autoreconf -i
-RUN ./configure --enable-mpi --enable-openmp
-
+RUN ./configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi"
 # Which optional dependencies are missing?
 RUN cat config.log | grep WARN > octopus-configlog-warnings
 RUN cat octopus-configlog-warnings

--- a/Dockerfile-develop
+++ b/Dockerfile-develop
@@ -63,7 +63,7 @@ RUN cat config.log | grep WARN > octopus-configlog-warnings
 RUN cat octopus-configlog-warnings
 
 # all in one line to make image smaller
-RUN make && make install && make clean && make distclean
+RUN make -j && make install && make clean && make distclean
 
 RUN echo "Section Issue 9 starts here. --------------"
 RUN echo "Issue 9: https://github.com/fangohr/octopus-in-docker/issues/9"
@@ -110,7 +110,7 @@ RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
 # test that the libraries are mentioned in theOptional libraries section of octopus output
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "cgal"
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "scalapack"
-RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "elpa"
+RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "ELPA"
 
 # offer directory for mounting container
 WORKDIR /io

--- a/Dockerfile-develop
+++ b/Dockerfile-develop
@@ -1,9 +1,9 @@
 FROM debian:bookworm
 
-# install Octopus develop version 
+# install Octopus develop version
 
 # Convenience tools (up to emacs)
-# Libraries that octopus needs 
+# Libraries that octopus needs
 # and optional dependencies (in alphabetical order)
 RUN apt-get -y update && apt-get -y install wget time nano vim emacs \
     autoconf \
@@ -96,7 +96,17 @@ ENV OMP_NUM_THREADS=1
 # run one MPI-enabled version
 RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus
 RUN cd /opt/octopus-examples/he && mpirun -np 2 octopus
-    
+
+# test the libraries used by octopus
+RUN cd /opt/octopus-examples/recipe && octopus > /tmp/octopus-recipe.out
+# test that the libraries are mentioned in the configuration options section of octopus output
+RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "openmp"
+RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
+# test that the libraries are mentioned in theOptional libraries section of octopus output
+RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "cgal"
+RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "scalapack"
+RUN sleep infinity
+
 # offer directory for mounting container
 WORKDIR /io
 

--- a/Dockerfile-develop
+++ b/Dockerfile-develop
@@ -105,7 +105,6 @@ RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
 # test that the libraries are mentioned in theOptional libraries section of octopus output
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "cgal"
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "scalapack"
-RUN sleep infinity
 
 # offer directory for mounting container
 WORKDIR /io


### PR DESCRIPTION
to be merged to main  after https://github.com/fangohr/octopus-in-docker/pull/15/files

Fixes partly https://github.com/fangohr/octopus-in-docker/issues/11
This MR adds:

- `FCFLAGS_ELPA`
- test for octopus linking against scalapack