### PR TITLE
Improve documentation after merging Dockerfiles

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -113,52 +113,34 @@ inside the container.
 
 There are two steps required:
 
-- Step 1: build the container image (only once) or download it (only once).
+- Step 1: build the container image (only once) or download it (only once). For
+  downloading a pre-compiled Docker image and using that, please see
+  instructions above "Quick Start".
 
-- Step 2: use the container to execute Octopus inside the container
+- Step 2: use the container to execute Octopus inside the container.
 
-
-Step 1: How obtain a Docker container image with Octopus
---------------------------------------------------------
+Build the Docker image on your computer
+---------------------------------------
 
 In this repository we provide a `Dockerfile <Dockerfile>`__ to compile Octopus
 in a container.
-
-Option A: Build the Docker image on your computer
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First clone this repository. Then run::
 
   docker build -f Dockerfile --build-arg VERSION_OCTOPUS=14.0 -t octimage
 
-to build Octopus version ``14.0`` in the container. To use the current
-development version of Octopus (from the
-`gitlab repository <https://gitlab.com/octopus-code/octopus>`__), use``VERSION_OCTOPUS=develop``
+to build Octopus version ``14.0`` in the container and create Docker image with name ``octimage``.
+
+To use the current development version of Octopus (from the `gitlab repository
+<https://gitlab.com/octopus-code/octopus>`__), use ``VERSION_OCTOPUS=develop``
 instead of ``VERSION_OCTOPUS=14.0``. Omitting the ``VERSION_OCTOPUS`` argument
 will by default pick the ``develop`` version.
 
 This will take some time to complete. (On Linux, you may need to prefix all
 docker calls with ``sudo``.)
 
-
-Option B: Download Docker image from Dockerhub
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Instead of building it yourself, you can also pull an image from Dockerhub
-(`available versions <https://hub.docker.com/r/fangohr/octopus/tags>`__) using::
-
-  docker pull fangohr/octopus:14.0
-
-and then move on to using this image in the next section, where you replace
-``octimage`` with ``fangohr/octopus:14.0``.
-
-If the ``docker pull`` command is not run, then docker will execute it
-automatically when a ``docker run`` command needs a particular image (such as
-``fangohr/octopus:14.0``).
-
-
-Step 2: Use the Docker image
-----------------------------
+Use the Docker image
+--------------------
 
 To use the Docker image::
 

--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ Quick start
      replace this with ``bash`` if you want to start octopus manually from inside
      the container.
 
-   This is tested and known to work on OSX and Windows. On Linux, there is a
+   This is tested and known to work on macOS and Windows. On Linux, there is a
    permissions issue if (numerical) user id on the host system and in the
    container deviate.
 

--- a/README.rst
+++ b/README.rst
@@ -122,25 +122,24 @@ Step 1: How obtain a Docker container image with Octopus
 --------------------------------------------------------
 
 In this repository we provide a `Dockerfile <Dockerfile>`__ to compile Octopus
-13.0 and `Dockerfile-develop <Dockerfile-develop>`__ to compile the ``develop``
-branch of the Octopus repository in a container.
-
-The following examples are for the 14.0 release version. (To build a container
-for the latest Octopus version from the ``develop`` branch, replace
-``Dockerfile`` with ``Dockerfile-develop``.)
+in a container.
 
 Option A: Build the Docker image on your computer
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 First clone this repository. Then run::
 
-  docker build -f Dockerfile -t octimage .
+  docker build -f Dockerfile --build-arg VERSION_OCTOPUS=14.0 -t octimage
 
-On Linux, you need to prefix all docker calls with ``sudo``::
+to build Octopus version ``14.0`` in the container. To use the current
+development version of Octopus (from the
+`gitlab repository <https://gitlab.com/octopus-code/octopus>`__), use``VERSION_OCTOPUS=develop``
+instead of ``VERSION_OCTOPUS=14.0``. Omitting the ``VERSION_OCTOPUS`` argument
+will by default pick the ``develop`` version.
 
-  sudo docker build -f Dockerfile -t octimage .
+This will take some time to complete. (On Linux, you may need to prefix all
+docker calls with ``sudo``.)
 
-This will take some time to complete.
 
 Option B: Download Docker image from Dockerhub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Introduction
 ------------
 
 If you have difficulties compiling Octopus, it might be useful to be able to run
-it in a container (for example on Windows or MacOS).
+it in a container (for example on Windows or macOS).
 
 The container provides a mini (Linux) Operating system, in which we can compile
 Octopus using a recipe (this is the Dockerfile, see below).
@@ -113,23 +113,23 @@ inside the container.
 
 There are two steps required:
 
-- Step 1: build the container image (only once) or download it (only once). For
+- Step 1: build the Docker image (only once) or download it (only once). For
   downloading a pre-compiled Docker image and using that, please see
   instructions above "Quick Start".
 
-- Step 2: use the container to execute Octopus inside the container.
+- Step 2: use Docker to execute Octopus inside the Docker container.
 
 Build the Docker image on your computer
 ---------------------------------------
 
 In this repository we provide a `Dockerfile <Dockerfile>`__ to compile Octopus
-in a container.
+inside a Docker container.
 
-First clone this repository. Then run::
+To do this, first clone this repository. Then run::
 
   docker build -f Dockerfile --build-arg VERSION_OCTOPUS=14.0 -t octimage
 
-to build Octopus version ``14.0`` in the container and create Docker image with name ``octimage``.
+to build Octopus version ``14.0`` in the container and create the Docker image with name ``octimage``.
 
 To use the current development version of Octopus (from the `gitlab repository
 <https://gitlab.com/octopus-code/octopus>`__), use ``VERSION_OCTOPUS=develop``

--- a/dev-notes.org
+++ b/dev-notes.org
@@ -2,13 +2,6 @@
 
 Potential points for improvement:
 
-- [[Dockerfile-debian][Dockerfile-debian]] and [[Dockerfile-debian-develop][Dockerfile-debian-develop]] are very similar, and so are
-  the ~.github/workflows~.
-
-- We currently build the containers for the architecture on which the job runs.
-  It should be possible to host docker images for multiple architectures (in
-  particular x86 and the M1/M2 processors) together at Dockerhub.
-
 - We use one particular combination of libraries and flags when compiling
   Octopus. This is not as flexible as using spack, for example. However, those
   flags etc can be adapted if necessary.


### PR DESCRIPTION
Closes https://github.com/fangohr/octopus-in-docker/issues/22

Summary:
- use of `macOS` instead of `MacOS` and `OSX`
- try to be clearer with container / image
- reduce duplication in text, and make whole file shorter
- explain meaning of `octimage` in developer section
- explain (new) default behaviour if `VERSION_OCTOPUS` is not specified.