### PR TITLE
LDLIBRARYPATH only needed when executed as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ FROM debian:bookworm
 # the version to install (latest stable or develop) is set by buildarg VERSION_OCTOPUS
 ARG VERSION_OCTOPUS=develop
 
-
+# On octopus>13 libsym (external-lib) is dynamically linked from /usr/local/lib.
+# As we run Octopus as root, we need to set LD_LIBRARY_PATH:
+ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 # Install octopus dependencies and compile octopus.
 WORKDIR /opt
@@ -13,10 +15,6 @@ COPY *.sh /opt
 RUN bash /opt/install_dependencies.sh
 #   bash /opt/install_octopus.sh $VERSION_OCTOPUS $OCTOPUS_SOURCE_DIR $OCTOPUS_INSTALL_DIR
 RUN bash /opt/install_octopus.sh $VERSION_OCTOPUS /opt/octopus
-
-# on octopus>13 libsym (external-lib) is dynamically linked and hence needs LD_LIBRARY_PATH set
-# see https://github.com/fangohr/octopus-in-docker/issues/9
-ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 WORKDIR /opt/octopus
 

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -79,20 +79,3 @@ cat octopus-configlog-warnings
 # all in one line to make image smaller
 make -j && make install && make clean && make distclean
 
-
-
-if [ $version == "develop" ]; then
-  # Set ENV variable for external libs (only needed for octopus14.0 onwards)
-  echo "Section Issue 9 starts here. --------------"
-  echo "Issue 9: https://github.com/fangohr/octopus-in-docker/issues/9"
-  # DEBUG output
-  ldd /usr/local/bin/octopus | grep libsym
-  echo $LD_LIBRARY_PATH
-  # Setting LD_LIBRARY_PATH as follows works around the octopus bug described in
-  # https://github.com/fangohr/octopus-in-docker/issues/9 and also referenced in
-  # https://gitlab.com/octopus-code/octopus/-/issues/886
-  export LD_LIBRARY_PATH="/usr/local/lib:$LD_LIBRARY_PATH"
-  echo $LD_LIBRARY_PATH
-  echo "Section Issue 9 ends here. ----------------"
-fi
-


### PR DESCRIPTION
(i.e. only in the container, and not in the script).

See
https://github.com/fangohr/octopus-in-docker/issues/9#issuecomment-1997219420

Addresses:
- https://github.com/fangohr/octopus-in-docker/issues/9
- https://github.com/fangohr/octopus-in-docker/issues/24