### PR TITLE
Update Octopus-develop version to main branch in Dockerfile and Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM debian:bookworm
 # install Octopus (latest stable or develop) on Debian
 
 # the version to install (latest stable or develop) is set by buildarg VERSION_OCTOPUS
-ARG VERSION_OCTOPUS=develop
+# the development version of octopus is hosted on the branch "main" in the official repository.
+ARG VERSION_OCTOPUS=main
 
 # the build system to use (autotools or cmake)
 ARG BUILD_SYSTEM=autotools

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ stable:
 	docker build -f Dockerfile --build-arg VERSION_OCTOPUS=${VERSION_OCTOPUS} --build-arg BUILD_SYSTEM=${BUILD_SYSTEM} -t octopus .
 
 develop:
-	docker build -f Dockerfile --build-arg VERSION_OCTOPUS=develop --build-arg BUILD_SYSTEM=${BUILD_SYSTEM} -t octopus-develop .
+	docker build -f Dockerfile --build-arg VERSION_OCTOPUS=main --build-arg BUILD_SYSTEM=${BUILD_SYSTEM} -t octopus-develop .
 
 .PHONY: stable develop dockerhub-update-multiarch
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # This Makefile is used to build the Docker image for Octopus.
 # EXAMPLE: make stable
 # EXAMPLE: make develop
+# EXAMPLE: make develop VERSION_OCTOPUS=custom_branch_on_octopus_repo
 # EXAMPLE: make stable VERSION_OCTOPUS=12.0
 # EXAMPLE: make stable VERSION_OCTOPUS=12.0 BUILD_SYSTEM=cmake
 VERSION_OCTOPUS?=14.0

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -9,7 +9,7 @@
 usage() {
   echo "Usage: $0 [--version <version_number>] [--download_dir <download_location>] [--install_dir <install_prefix>] [--build_system <autotools|cmake>]"
   echo "Options:"
-  echo "  --version <version_number>      Specify the version number of Octopus (e.g., 13.0, develop)"
+  echo "  --version <version_number>      Specify the version number / branch name of Octopus (e.g., 13.0, develop, test-branch-a)"
   echo "  --download_dir <download_location>   Specify the download location for Octopus source (default: current directory)"
   echo "  --install_dir <install_prefix>   Specify the install prefix for Octopus (default: /usr/local)"
   echo "  --build_system <autotools|cmake> Specify the build system to use (default: autotools)"
@@ -51,14 +51,13 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Set the default branch of the octopus code
-default_branch=main
 
 # Check if the version number and location is provided
 if [ -z "$version" ]; then
   echo "No version number provided"
   usage
 fi
+
 
 if [ -z "$location" ]; then
   echo "No download location provided, using current directory"
@@ -88,31 +87,38 @@ mkdir -p "$location"
 
 cd "$location"
 
-# if develop is provided, clone the main branch
 
-if [ $version == $default_branch ]; then
-  git clone https://gitlab.com/octopus-code/octopus.git .
-else
+# decide if we are using a branch from source or a release
+# Rule: if the version number is numeric then it is a release (e.g., 13.0, 11.3, 14.1 etc.).
+#       Anything else is then a branch (e.g., develop, test-branch-a, main etc.)
+# then perform 3 steps:
+# 1. download / clone  the source
+# 2. unpack the source / checkout the branch
+# 2. record the metadata of the source (release version / branch commit hash, date)
+
+date=$(date)
+if [[ $version =~ ^[0-9]+(\.[0-9]+)$ ]]; then
+  echo "Downloading Octopus release version '$version'"
   # download the tar file
   wget https://octopus-code.org/download/${version}/octopus-${version}.tar.gz
   tar -xvf octopus-${version}.tar.gz
   mv octopus-$version/* .
   rm -rf octopus-$version
   # rm octopus-$version.tar.gz
-fi
 
-date=$(date)
-
-# Record the version number and date
-if [ $version == "develop" ]; then
-    # Record which version we are using
-    git show > octopus-source-version
-    echo "octopus-source-clone-date: $date " >> octopus-source-version
+  # Record which version we are using
+  git show > octopus-source-version
+  echo "octopus-source-clone-date: $date " >> octopus-source-version
 else
+  echo "Cloning Octopus branch '$version'"
+  git clone https://gitlab.com/octopus-code/octopus.git .
+  git checkout $version
+
   # Record which version we are using
   echo "octopus-source-version: $version " > octopus-source-version
   echo "octopus-source-download-date: $date " >> octopus-source-version
 fi
+
 
 # Build octopus
 if [ $build_system == "cmake" ]; then

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -107,16 +107,16 @@ if [[ $version =~ ^[0-9]+(\.[0-9]+)$ ]]; then
   # rm octopus-$version.tar.gz
 
   # Record which version we are using
-  git show > octopus-source-version
-  echo "octopus-source-clone-date: $date " >> octopus-source-version
+  echo "octopus-source-version: $version " > octopus-source-version
+  echo "octopus-source-download-date: $date " >> octopus-source-version
 else
   echo "Cloning Octopus branch '$version'"
   git clone https://gitlab.com/octopus-code/octopus.git .
   git checkout $version
 
   # Record which version we are using
-  echo "octopus-source-version: $version " > octopus-source-version
-  echo "octopus-source-download-date: $date " >> octopus-source-version
+  git show > octopus-source-version
+  echo "octopus-source-clone-date: $date " >> octopus-source-version
 fi
 
 

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -2,7 +2,7 @@
 # This script prepares the download of octopus in the right location given the version number, location to untar / clone and install prefix
 # example run:
 # $ ./install_octopus.sh --version 13.0 --download_dir /opt/octopus --install_dir /home/user/octopus-bin --build_system autotools
-# $ ./install_octopus.sh --version develop --download_dir /opt/octopus --build_system cmake
+# $ ./install_octopus.sh --version main --download_dir /opt/octopus --build_system cmake
 # Consider running install_dependencies.sh first to install all the dependencies on a debian based system
 
 # Function to display script usage
@@ -51,6 +51,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Set the default branch of the octopus code
+default_branch=main
+
 # Check if the version number and location is provided
 if [ -z "$version" ]; then
   echo "No version number provided"
@@ -87,7 +90,7 @@ cd "$location"
 
 # if develop is provided, clone the main branch
 
-if [ $version == "develop" ]; then
+if [ $version == $default_branch ]; then
   git clone https://gitlab.com/octopus-code/octopus.git .
 else
   # download the tar file
@@ -102,9 +105,9 @@ date=$(date)
 
 # Record the version number and date
 if [ $version == "develop" ]; then
-  # Record which version we are using
-  git log -1 --pretty=format:'%H %D' > octopus-source-version
-  echo "octopus-source-clone-date: $date " >> octopus-source-version
+    # Record which version we are using
+    git show > octopus-source-version
+    echo "octopus-source-clone-date: $date " >> octopus-source-version
 else
   # Record which version we are using
   echo "octopus-source-version: $version " > octopus-source-version

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -9,7 +9,7 @@
 usage() {
   echo "Usage: $0 [--version <version_number>] [--download_dir <download_location>] [--install_dir <install_prefix>] [--build_system <autotools|cmake>]"
   echo "Options:"
-  echo "  --version <version_number>      Specify the version number / branch name of Octopus (e.g., 13.0, develop, test-branch-a)"
+  echo "  --version <version_number>      Specify the version number / branch name of Octopus (e.g., 13.0, main, test-branch-a)"
   echo "  --download_dir <download_location>   Specify the download location for Octopus source (default: current directory)"
   echo "  --install_dir <install_prefix>   Specify the install prefix for Octopus (default: /usr/local)"
   echo "  --build_system <autotools|cmake> Specify the build system to use (default: autotools)"


### PR DESCRIPTION
Closes https://github.com/fangohr/octopus-in-docker/issues/29
- Provides the ability to compile Octopus from any branch ( the docker container is tagged as develop )
eg: 
```console
make develop VERSION_OCTOPUS=custom_branch_on_octopus_repo
make develop VERSION_OCTOPUS=main
make develop VERSION_OCTOPUS=fix-abc
```
or to compile natively:
```console
bash install_octopus.sh --version main --download_dir /opt/octopus 
bash install_octopus.sh --version fix-abc --download_dir /opt/octopus 
```