### PR TITLE
Refactor install_octopus.sh script to support command-line arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ ENV LD_LIBRARY_PATH="/usr/local/lib"
 WORKDIR /opt
 COPY *.sh /opt
 RUN bash /opt/install_dependencies.sh && rm -rf /var/lib/apt/lists/*
-#   bash /opt/install_octopus.sh $VERSION_OCTOPUS $OCTOPUS_SOURCE_DIR $OCTOPUS_INSTALL_DIR
-RUN bash /opt/install_octopus.sh $VERSION_OCTOPUS /opt/octopus
+RUN bash /opt/install_octopus.sh --version $VERSION_OCTOPUS --download_dir /opt/octopus
 
 WORKDIR /opt/octopus
 

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -12,7 +12,7 @@ usage() {
   echo "Usage: $0 [--version <version_number>] [--download_dir <download_location>] [--install_dir <install_prefix>]"
   echo "Options:"
   echo "  --version <version_number>      Specify the version number of Octopus (e.g., 13.0, develop)"
-  echo "  --download_dir <download_location>   Specify the download location for Octopus source"
+  echo "  --download_dir <download_location>   Specify the download location for Octopus source (default: current directory)"
   echo "  --install_dir <install_prefix>   Specify the install prefix for Octopus (default: /usr/local)"
   echo "  -h, --help                      Display this help message"
   exit 1
@@ -54,8 +54,8 @@ if [ -z "$version" ]; then
 fi
 
 if [ -z "$location" ]; then
-  echo "No download location provided"
-  usage
+  echo "No download location provided, using current directory"
+  location=$(pwd)
 fi
 
 if [ -z "$prefix" ]; then

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -89,7 +89,7 @@ date=$(date)
 # Record the version number and date
 if [ $version == "develop" ]; then
   # Record which version we are using
-  git show > octopus-source-version
+  git log -1 --pretty=format:'%H %D' > octopus-source-version
   echo "octopus-source-clone-date: $date " >> octopus-source-version
 else
   # Record which version we are using

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -1,66 +1,100 @@
 #!/bin/bash
 # This script prepares the download of octopus in the right location given the version number, location to untar / clone and install prefix
 # example run:
-# $ ./install_octopus.sh 13.0 /opt/octopus /home/user/octopus-bin
-# $ ./install_octopus.sh develop /opt/octopus
-# Consider runing install_dependencies.sh first to install all the dependencies on a debian based system
+# $ ./install_octopus.sh --version 13.0 --download_dir /opt/octopus --install_dir /home/user/octopus-bin
+# $ ./install_octopus.sh --version develop --download_dir /opt/octopus
+# Consider running install_dependencies.sh first to install all the dependencies on a debian based system
 
-# exit on error and print each command
-set -xe
+
+
+# Function to display script usage
+usage() {
+  echo "Usage: $0 [--version <version_number>] [--download_dir <download_location>] [--install_dir <install_prefix>]"
+  echo "Options:"
+  echo "  --version <version_number>      Specify the version number of Octopus (e.g., 13.0, develop)"
+  echo "  --download_dir <download_location>   Specify the download location for Octopus source"
+  echo "  --install_dir <install_prefix>   Specify the install prefix for Octopus (default: /usr/local)"
+  echo "  -h, --help                      Display this help message"
+  exit 1
+}
+
+# Parse command-line arguments
+while [[ $# -gt 0 ]]; do
+  key="$1"
+  case $key in
+    --version)
+      version="$2"
+      shift
+      shift
+      ;;
+    --download_dir)
+      location="$2"
+      shift
+      shift
+      ;;
+    --install_dir)
+      prefix="$2"
+      shift
+      shift
+      ;;
+    -h|--help)
+      usage
+      ;;
+    *)
+      echo "Invalid option: $1"
+      usage
+      ;;
+  esac
+done
 
 # Check if the version number and location is provided
-if [ -z "$1" ]
-  then
-    echo "No version number provided"
-    exit 1
-else
-  version=$1
-fi
-if [ -z "$2" ]
-  then
-    echo "No download location provided"
-    exit 1
-else
-    location=$2
-fi
-if [ -z "$3" ]
-  then
-    echo "No install prefix provided using default location"
-    prefix=/usr/local
-else
-    prefix=$3
+if [ -z "$version" ]; then
+  echo "No version number provided"
+  usage
 fi
 
-# make the location if it does not exist
-if [ ! -d $location ]; then
-  mkdir -p $location
+if [ -z "$location" ]; then
+  echo "No download location provided"
+  usage
 fi
-cd $location
+
+if [ -z "$prefix" ]; then
+  echo "No install prefix provided using default location"
+  prefix="/usr/local"
+fi
+
+## MAIN ##
+# exit on error and print each command
+set -xe
+# make the location if it does not exist
+mkdir -p "$location"
+
+cd "$location"
 
 # if develop is provided, clone the main branch
 
 if [ $version == "develop" ]; then
   git clone https://gitlab.com/octopus-code/octopus.git .
 else
-    # download the tar file
-    wget https://octopus-code.org/download/${version}/octopus-${version}.tar.gz
-    tar -xvf octopus-${version}.tar.gz
-    mv octopus-$version/* .
-    rm -rf octopus-$version
-    # rm octopus-$version.tar.gz
+  # download the tar file
+  wget https://octopus-code.org/download/${version}/octopus-${version}.tar.gz
+  tar -xvf octopus-${version}.tar.gz
+  mv octopus-$version/* .
+  rm -rf octopus-$version
+  # rm octopus-$version.tar.gz
 fi
 
 date=$(date)
 
 # Record the version number and date
 if [ $version == "develop" ]; then
-    # Record which version we are using
-    git show > octopus-source-version
-    echo "octopus-source-clone-date: $date " >> octopus-source-version
+  # Record which version we are using
+  git show > octopus-source-version
+  echo "octopus-source-clone-date: $date " >> octopus-source-version
 else
-    # Record which version we are using
-    echo "octopus-source-version: $version " > octopus-source-version
-    echo "octopus-source-download-date: $date " >> octopus-source-version
+  # Record which version we are using
+  echo "octopus-source-version: $version " > octopus-source-version
+  echo "octopus-source-download-date: $date " >> octopus-source-version
 fi
 
 autoreconf -i
@@ -70,7 +104,7 @@ autoreconf -i
 export FCFLAGS_ELPA="-I/usr/include -I/usr/include/elpa/modules"
 mkdir _build && pushd _build
 # configure
-../configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi" --prefix=$prefix
+../configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi" --prefix="$prefix"
 
 # Which optional dependencies are missing?
 cat config.log | grep WARN > octopus-configlog-warnings


### PR DESCRIPTION
Before
```console
# example run:
$ ./install_octopus.sh 13.0 /opt/octopus /home/user/octopus-bin
# $ ./install_octopus.sh develop /opt/octopus
```
After
```console
# example run:
$ ./install_octopus.sh --version 13.0 --download_dir /opt/octopus --install_dir /home/user/octopus-bin
$ ./install_octopus.sh --version develop --download_dir /opt/octopus
```

```console
❯ bash install_octopus.sh --help
Usage: install_octopus.sh [--version <version_number>] [--download_dir <download_location>] [--install_dir <install_prefix>]
Options:
  --version <version_number>      Specify the version number of Octopus (e.g., 13.0, develop)
  --download_dir <download_location>   Specify the download location for Octopus source
  --install_dir <install_prefix>   Specify the install prefix for Octopus (default: /usr/local)
  -h, --help                      Display this help message

```