### PR TITLE
[cmake_test] remove libxc patch 

### DIFF
--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -118,7 +118,7 @@ if [ $build_system == "cmake" ]; then
   echo "Requires: spglib" >> /usr/lib/x86_64-linux-gnu/pkgconfig/spglib_f08.pc
 
   # Remove libxc CMake files because they are not packaged correctly
-  rm -rf /usr/share/cmake/Libxc/
+  # rm -rf /usr/share/cmake/Libxc/
 
   # configure
   cmake --preset default -DOCTOPUS_OpenMP=ON -DOCTOPUS_MPI=ON -DOCTOPUS_ScaLAPACK=ON -G Ninja --install-prefix "$prefix"


### PR DESCRIPTION
NOT TO BE MERGED.
A CI run to determine what happens without the Libxc patch and to check when the upstream solves this problem.