### PR TITLE
[cmake_test] test spglib patch

### DIFF
--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -115,7 +115,7 @@ fi
 if [ $build_system == "cmake" ]; then
 
   # Patch spglib packaging issues
-  echo "Requires: spglib" >> /usr/lib/x86_64-linux-gnu/pkgconfig/spglib_f08.pc
+  # echo "Requires: spglib" >> /usr/lib/x86_64-linux-gnu/pkgconfig/spglib_f08.pc
 
   # Remove libxc CMake files because they are not packaged correctly
   rm -rf /usr/share/cmake/Libxc/


### PR DESCRIPTION
NOT TO BE MERGED.
A CI run to determine what happens without the psglib patch and to check when the upstream solves this problem.