### PR TITLE
GPU enabled - Jason

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,16 +32,12 @@ RUN bash /opt/install_octopus.sh --version $VERSION_OCTOPUS --download_dir /opt/
 
 # CUDA will be disabled via environmental variables during testing for building on machines w/o GPU devices
 
-# Enable parsing environmental variables 
-# By doing this, GPU can be disabled by setting OCT_DisableAccel=1
-ENV OCT_PARSE_ENV=1
-
 # Change work directory
 WORKDIR /opt/octopus
 
 # Show octopus version
-RUN OCT_DisableAccel=1 octopus --version > octopus-version
-RUN OCT_DisableAccel=1 octopus --version
+RUN octopus --version > octopus-version
+RUN octopus --version
 
 # The next command returns an error code as some tests fail
 # RUN make check-short
@@ -50,9 +46,9 @@ RUN mkdir -p /opt/octopus-examples
 COPY examples /opt/octopus-examples
 
 # Instead of tests, run two short examples
-RUN cd /opt/octopus-examples/recipe && OCT_DisableAccel=1 octopus
-RUN cd /opt/octopus-examples/h-atom && OCT_DisableAccel=1 octopus
-RUN cd /opt/octopus-examples/he && OCT_DisableAccel=1 octopus
+RUN cd /opt/octopus-examples/recipe && octopus
+RUN cd /opt/octopus-examples/h-atom && octopus
+RUN cd /opt/octopus-examples/he && octopus
 
 # allow root execution of mpirun
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
@@ -63,11 +59,11 @@ ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 #ENV OMP_NUM_THREADS=1
 
 # run one MPI-enabled version
-RUN cd /opt/octopus-examples/he && OCT_DisableAccel=1 mpirun -np 1 octopus
-RUN cd /opt/octopus-examples/he && OCT_DisableAccel=1 mpirun -np 2 octopus
+RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus
+RUN cd /opt/octopus-examples/he && mpirun -np 2 octopus
 
 # test the libraries used by octopus
-RUN cd /opt/octopus-examples/recipe && OCT_DisableAccel=1 octopus > /tmp/octopus-recipe.out
+RUN cd /opt/octopus-examples/recipe && octopus > /tmp/octopus-recipe.out
 # test that the libraries are mentioned in the configuration options section of octopus output
 RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "openmp"
 RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,13 +24,13 @@ WORKDIR /opt
 COPY *.sh /opt
 RUN bash /opt/install_dependencies.sh && rm -rf /var/lib/apt/lists/*
 RUN bash /opt/install_octopus.sh --version $VERSION_OCTOPUS --download_dir /opt/octopus --build_system autotools
-
+RUN rm /opt/*.sh
 
 # ---------------------------------------------------------------------
 # Test Octopus
 # ---------------------------------------------------------------------
 
-# CUDA will be disabled via environmental variables during testing for building on machines w/o GPU devices
+# CUDA is disabled by default for testing on machines w/o GPU devices
 
 # Change work directory
 WORKDIR /opt/octopus
@@ -55,8 +55,8 @@ ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 # set number of OpenMP threads to 1 by default
-# Disabled because most of HPC users will customize by running with srun. -Jason
-#ENV OMP_NUM_THREADS=1
+# Only during test phase because users will most likely customize it when running actual jobs. -Jason
+ARG OMP_NUM_THREADS=1
 
 # run one MPI-enabled version
 RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,23 @@
 FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 
-# install Octopus (latest stable or develop) on Debian
+# ---------------------------------------------------------------------
+# Install Octopus (latest stable or develop) on CUDA container
+# ---------------------------------------------------------------------
 
 # the version to install (latest stable or develop) is set by buildarg VERSION_OCTOPUS
 # the development version of octopus is hosted on the branch "main" in the official repository.
-ARG VERSION_OCTOPUS=main
+ARG VERSION_OCTOPUS=14.0
 
 # the build system to use (autotools or cmake) 
-# Disabled for GPU support. CUDA base image only supports Ubuntu up to 22.04, 
-#   and "libspglib-f08-dev" is not supported as of Apr 2024. -Jason
+# Disabled for GPU support and will use autotools only as of Apr 2024).
+#   CUDA base image only supports Ubuntu up to 22.04, and "libspglib-f08-dev" 
+#   required by cmake is not supported as of Apr 2024. -Jason
 #ARG BUILD_SYSTEM=autotools
 
 # On octopus>13 libsym (external-lib) is dynamically linked from /usr/local/lib.
+# Also find CUDA toolkits and drivers. -Jason
 # As we run Octopus as root, we need to set LD_LIBRARY_PATH:
-ENV LD_LIBRARY_PATH="/usr/local/lib"
+ENV LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:/usr/local/cuda-12.4/compat/
 
 # Install octopus dependencies and compile octopus.
 WORKDIR /opt
@@ -21,10 +25,23 @@ COPY *.sh /opt
 RUN bash /opt/install_dependencies.sh && rm -rf /var/lib/apt/lists/*
 RUN bash /opt/install_octopus.sh --version $VERSION_OCTOPUS --download_dir /opt/octopus --build_system autotools
 
+
+# ---------------------------------------------------------------------
+# Test Octopus
+# ---------------------------------------------------------------------
+
+# CUDA will be disabled via environmental variables during testing for building on machines w/o GPU devices
+
+# Enable parsing environmental variables 
+# By doing this, GPU can be disabled by setting OCT_DisableAccel=1
+ENV OCT_PARSE_ENV=1
+
+# Change work directory
 WORKDIR /opt/octopus
 
-RUN octopus --version > octopus-version
-RUN octopus --version
+# Show octopus version
+RUN OCT_DisableAccel=1 octopus --version > octopus-version
+RUN OCT_DisableAccel=1 octopus --version
 
 # The next command returns an error code as some tests fail
 # RUN make check-short
@@ -33,23 +50,24 @@ RUN mkdir -p /opt/octopus-examples
 COPY examples /opt/octopus-examples
 
 # Instead of tests, run two short examples
-RUN cd /opt/octopus-examples/recipe && octopus
-RUN cd /opt/octopus-examples/h-atom && octopus
-RUN cd /opt/octopus-examples/he && octopus
+RUN cd /opt/octopus-examples/recipe && OCT_DisableAccel=1 octopus
+RUN cd /opt/octopus-examples/h-atom && OCT_DisableAccel=1 octopus
+RUN cd /opt/octopus-examples/he && OCT_DisableAccel=1 octopus
 
 # allow root execution of mpirun
 ENV OMPI_ALLOW_RUN_AS_ROOT=1
 ENV OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
 
 # set number of OpenMP threads to 1 by default
-ENV OMP_NUM_THREADS=1
+# Disabled because most of HPC users will customize by running with srun. -Jason
+#ENV OMP_NUM_THREADS=1
 
 # run one MPI-enabled version
-RUN cd /opt/octopus-examples/he && mpirun -np 1 octopus
-RUN cd /opt/octopus-examples/he && mpirun -np 2 octopus
+RUN cd /opt/octopus-examples/he && OCT_DisableAccel=1 mpirun -np 1 octopus
+RUN cd /opt/octopus-examples/he && OCT_DisableAccel=1 mpirun -np 2 octopus
 
 # test the libraries used by octopus
-RUN cd /opt/octopus-examples/recipe && octopus > /tmp/octopus-recipe.out
+RUN cd /opt/octopus-examples/recipe && OCT_DisableAccel=1 octopus > /tmp/octopus-recipe.out
 # test that the libraries are mentioned in the configuration options section of octopus output
 RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "openmp"
 RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
@@ -57,6 +75,11 @@ RUN grep "Configuration options" /tmp/octopus-recipe.out | grep "mpi"
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "cgal"
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "scalapack"
 RUN grep "Optional libraries" /tmp/octopus-recipe.out | grep "ELPA"
+
+
+# ---------------------------------------------------------------------
+# Finishing
+# ---------------------------------------------------------------------
 
 # offer directory for mounting container
 WORKDIR /io

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 
 # install Octopus (latest stable or develop) on Debian
 
@@ -6,8 +6,10 @@ FROM debian:bookworm
 # the development version of octopus is hosted on the branch "main" in the official repository.
 ARG VERSION_OCTOPUS=main
 
-# the build system to use (autotools or cmake)
-ARG BUILD_SYSTEM=autotools
+# the build system to use (autotools or cmake) 
+# Disabled for GPU support. CUDA base image only supports Ubuntu up to 22.04, 
+#   and "libspglib-f08-dev" is not supported as of Apr 2024. -Jason
+#ARG BUILD_SYSTEM=autotools
 
 # On octopus>13 libsym (external-lib) is dynamically linked from /usr/local/lib.
 # As we run Octopus as root, we need to set LD_LIBRARY_PATH:
@@ -17,7 +19,7 @@ ENV LD_LIBRARY_PATH="/usr/local/lib"
 WORKDIR /opt
 COPY *.sh /opt
 RUN bash /opt/install_dependencies.sh && rm -rf /var/lib/apt/lists/*
-RUN bash /opt/install_octopus.sh --version $VERSION_OCTOPUS --download_dir /opt/octopus --build_system $BUILD_SYSTEM
+RUN bash /opt/install_octopus.sh --version $VERSION_OCTOPUS --download_dir /opt/octopus --build_system autotools
 
 WORKDIR /opt/octopus
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -27,6 +27,7 @@ apt-get -y install wget time nano vim emacs \
     libelpa-dev \
     libetsf-io-dev \
     libfftw3-dev \
+    libfftw3-mpi-dev \
     libgmp-dev \
     libgsl-dev \
     liblapack-dev \
@@ -34,7 +35,6 @@ apt-get -y install wget time nano vim emacs \
     libmpfr-dev \
     libnetcdff-dev \
     libnlopt-dev \
-    libopenmpi-dev \
     libscalapack-mpi-dev \
     libspfft-dev \
     libtool \
@@ -44,12 +44,26 @@ apt-get -y install wget time nano vim emacs \
     openctm-tools \
     pkg-config \
     procps
+#    libopenmpi-dev \
 
 
 # Add optional packages not needed by octopus (for visualization)
 apt-get -y install gnuplot
 
+# Install OpenMPI w/ PMI2
+apt-get install -y build-essential
+apt-get install -y wget hwloc libpmi2-0 libpmi2-0-dev
+wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.2.tar.gz
+tar zxvf openmpi-4.1.2.tar.gz && rm openmpi-4.1.2.tar.gz
+cd openmpi-4.1.2
+./configure --with-hwloc=internal --with-slurm \
+    --with-pmi=/usr --with-pmi-libdir=/usr/lib/x86_64-linux-gnu --without-verbs
+make -j $(nproc)
+make install
+
 # Add packages required to build via cmake
-apt-get -y install \
-    cmake ninja-build pkgconf \
-    libsymspg-dev libspglib-f08-dev
+# Disabled for GPU support. CUDA base image only supports Ubuntu up to 22.04, 
+#   and "libspglib-f08-dev" required by cmake is not supported as of Apr 2024. -Jason
+#apt-get -y install \
+#    cmake ninja-build pkgconf \
+#    libsymspg-dev libspglib-f08-dev

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -60,6 +60,7 @@ cd openmpi-4.1.2
     --with-pmi=/usr --with-pmi-libdir=/usr/lib/x86_64-linux-gnu --without-verbs
 make -j $(nproc)
 make install
+cd .. && rm -rf openmpi-4.1.2
 
 # Add packages required to build via cmake
 # Disabled for GPU support. CUDA base image only supports Ubuntu up to 22.04, 
@@ -67,3 +68,6 @@ make install
 #apt-get -y install \
 #    cmake ninja-build pkgconf \
 #    libsymspg-dev libspglib-f08-dev
+
+# Clean up
+apt clean

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -175,6 +175,3 @@ elif [ $build_system == "autotools" ]; then
   make distclean
   popd
 fi
-
-# Clean up
-rm -rf $location

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -119,6 +119,12 @@ else
   echo "octopus-source-clone-date: $date " >> octopus-source-version
 fi
 
+# Force disable GPU by default. -Jason
+# Explanation: GPU is not always advatangeous for current settings, but will be enabled by 
+#    default if Octopus is compiled with CUDA. Forcing it to disable, and only enable when
+#    user explicitly indicated.
+sed -ie "s/'DisableAccel', default/'DisableAccel', .true./" src/basic/accel.F90
+
 
 # Build octopus
 if [ $build_system == "cmake" ]; then
@@ -170,3 +176,5 @@ elif [ $build_system == "autotools" ]; then
   popd
 fi
 
+# Clean up
+rm -rf $location

--- a/install_octopus.sh
+++ b/install_octopus.sh
@@ -154,9 +154,9 @@ elif [ $build_system == "autotools" ]; then
 
   # We need to set FCFLAGS_ELPA as the octopus m4 has a bug
   # see https://gitlab.com/octopus-code/octopus/-/issues/900
-  export FCFLAGS_ELPA="-I/usr/include -I/usr/include/elpa/modules"
+  export FCFLAGS_ELPA="-I/usr/include -I/usr/include/elpa/modules -fallow-argument-mismatch "
   # configure
-  ../configure --enable-mpi --enable-openmp --with-blacs="-lscalapack-openmpi" --prefix="$prefix"
+  ../configure --enable-mpi --enable-openmp --enable-cuda --with-cuda-prefix=/usr/local/cuda --with-blacs="-lscalapack-openmpi" --prefix="$prefix"
 
   # Which optional dependencies are missing?
   cat config.log | grep WARN > octopus-configlog-warnings

--- a/singularity.def
+++ b/singularity.def
@@ -1,0 +1,56 @@
+Bootstrap: docker
+From: nvidia/cuda:12.4.1-devel-ubuntu22.04
+
+
+################################################################################
+%labels
+################################################################################
+
+Maintainer      Jason Li
+Version         14.0
+Description     Octopus is a software package for density-functional theory (DFT), and time-dependent density functional theory (TDDFT).
+
+
+################################################################################
+%environment
+################################################################################
+
+# On octopus>13 libsym (external-lib) is dynamically linked from /usr/local/lib.
+# Also find CUDA toolkits and drivers.
+export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:/usr/local/cuda-12.4/compat/
+
+
+################################################################################
+%files
+################################################################################
+
+install_dependencies.sh /opt
+install_octopus.sh /opt
+
+
+################################################################################
+%setup
+################################################################################
+
+echo "
+WARNING: This recipe must be built in its current directory. 
+         If you receive error, please change to its current directory and build again."
+
+
+################################################################################
+%post
+################################################################################
+
+# the version to install (latest stable or develop) is set by buildarg VERSION_OCTOPUS
+# the development version of octopus is hosted on the branch "main" in the official repository.
+export VERSION_OCTOPUS=14.0
+
+# On octopus>13 libsym (external-lib) is dynamically linked from /usr/local/lib.
+# Also find CUDA toolkits and drivers. 
+export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/cuda/lib64:/usr/local/cuda-12.4/compat/
+
+# Install octopus dependencies and compile octopus.
+cd /opt
+bash /opt/install_dependencies.sh && rm -rf /var/lib/apt/lists/*
+bash /opt/install_octopus.sh --version $VERSION_OCTOPUS --download_dir /opt/octopus --build_system autotools
+rm /opt/*.sh


### PR DESCRIPTION
Updated Dockerfile and installation scripts to enable GPUs. Several things to notice:

1. This Dockerfile is based on CUDA official containers (Ubuntu 22.04 based) instead of Debian Bookworm to enable CUDA.
2. Cmake option is disabled because one dependency is not supported in Ubuntu 22.04. 
3. Manually compiled PMI2 enabled OpenMPI (For Slurm jobs)
4. Changed "OMP_NUM_THREADS=1" from "ENV" to "ARG" (Reason: This is fine as a build-time test. But in real-world runs, users are likely to tweak the parameters to find optimized configurations)
5. Added Singularity recipe (testing not included)