### PR TITLE
Fix copy command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 # Install octopus dependencies and compile octopus.
 WORKDIR /opt
-COPY *.sh /opt
+COPY *.sh /opt/
 RUN bash /opt/install_dependencies.sh && rm -rf /var/lib/apt/lists/*
 RUN bash /opt/install_octopus.sh --version $VERSION_OCTOPUS --download_dir /opt/octopus --build_system $BUILD_SYSTEM
 


### PR DESCRIPTION
Copy for multiple files must end with an `/` in the target (from https://docs.docker.com/reference/dockerfile/#source-1).
Otherwise building octopus-15.0 (with make/autotools) works fine (I used `docker build --build-arg VERSION_OCTOPUS=15.0 . -t octimage:15.0`).